### PR TITLE
Add missing types for phpstan

### DIFF
--- a/stubs/Tideways.php
+++ b/stubs/Tideways.php
@@ -76,7 +76,7 @@ namespace Tideways\Profiler {
         public function getId(): string {}
 
         /**
-         * @param array<string,string> $annotations
+         * @param array<string,int|string|bool> $annotations
          */
         public function annotate(array $annotations): void {}
 

--- a/stubs/Tideways.php
+++ b/stubs/Tideways.php
@@ -22,9 +22,12 @@ namespace Tideways {
 
         public static function ignoreTransaction(): void {}
 
-        public static function logFatal(string $message, string $file, int $line, ?string $type = null, ?array $trace = null) {}
+        /**
+         * @param array<string>|null $trace
+         */
+        public static function logFatal(string $message, string $file, int $line, ?string $type = null, ?array $trace = null): void {}
 
-        public static function logException(\Throwable $exception) {}
+        public static function logException(\Throwable $exception): void {}
 
         public static function getTransactionName(): ?string {}
 
@@ -50,6 +53,9 @@ namespace Tideways {
 
         public static function addEventMarker(string $eventName): void {}
 
+        /**
+         * @param mixed $value
+         */
         public static function setCustomVariable(string $name, $value): void {}
 
         public static function currentTraceId(): ?string {}
@@ -69,6 +75,9 @@ namespace Tideways\Profiler {
 
         public function getId(): string {}
 
+        /**
+         * @param array<string,string> $annotations
+         */
         public function annotate(array $annotations): void {}
 
         public function logException(\Throwable $exception): void {}


### PR DESCRIPTION
This stub file is a nice improvement for us, thanks :+1: 

We added the stub file also for phpstan so in our codebase the tideways usages can be inspected but there are some required types missing in the stub file.


# How to reproduce

```
$ cat phpstan.neon
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: phpstan.neon
───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ parameters:
   2   │     level: max
   3   │     stubFiles:
   4   │         - ./stubs/Tideways.php
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/www/ext-tideways-stubs (main)
$ php phpstan.phar analyse stubs
Note: Using configuration file /home/bcremer/www/ext-tideways-stubs/phpstan.neon.
    0 [▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░]

 ------ ---------------------------------------------------------------------------------------------------------------------------
  Line   Tideways.php
 ------ ---------------------------------------------------------------------------------------------------------------------------
  25     Method Tideways\Profiler::logFatal() has no return typehint specified.
  25     Method Tideways\Profiler::logFatal() has parameter $trace with no value type specified in iterable type array.
  27     Method Tideways\Profiler::logException() has no return typehint specified.
  53     Method Tideways\Profiler::setCustomVariable() has parameter $value with no typehint specified.
  72     Method Tideways\Profiler\Span::annotate() has parameter $annotations with no value type specified in iterable type array.
 ------ ---------------------------------------------------------------------------------------------------------------------------


 [ERROR] Found 5 errors
```

# After the patch is applied

```
~/www/ext-tideways-stubs (add-missing-types*)
$ php phpstan.phar analyse stubs
Note: Using configuration file /home/bcremer/www/ext-tideways-stubs/phpstan.neon.
    0 [▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░]



 [OK] No errors
```
