### PR TITLE
More precise typehint for value parameter of setCustomVariable

### DIFF
--- a/stubs/Tideways.php
+++ b/stubs/Tideways.php
@@ -54,7 +54,7 @@ namespace Tideways {
         public static function addEventMarker(string $eventName): void {}
 
         /**
-         * @param mixed $value
+         * @param object|string|int|float|bool|null $value
          */
         public static function setCustomVariable(string $name, $value): void {}
 


### PR DESCRIPTION
fixes #2

setCustomVariable don't support arrays, but it support anything that can be casted to a string