### PR TITLE
Add Profiler::markAsWebTransaction

### DIFF
--- a/stubs/Tideways.php
+++ b/stubs/Tideways.php
@@ -68,6 +68,9 @@ namespace Tideways {
         public static function generateDistributedTracingHeaders(): array {}
         public static function generateReferencedTracesHeaders(): array {}
 
+        /** @since tideways 5.4.36 **/
+        public static function markAsWebTransaction(): void {}
+        
         /** @since tideways 5.5.6 **/
         public static function markPageCacheHit(): void {}
 


### PR DESCRIPTION
Add stub for `Profiler::markAsWebTransaction` added in Tideways 5.4.36.

See: https://tideways.com/profiler/blog/changelog/php-extension-5-4-36