### PR TITLE
Improve Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,26 @@
 
 Install with
 
-```
-composer require-dev tideways/ext-tideways-stubs
+```sh
+composer require --dev tideways/ext-tideways-stubs
 ```
 
 # PHPStan
 
-Add our stub in your `phpstan.neon`
+The stubs can be used to improve the PHPStan analysis when using classes from the Tideways extension. In order to do so, add the stub to your `phpstan.neon`:
 
-```
+```neon
 parameters:
     stubFiles:
         - vendor/tideways/ext-tideways-stubs/stubs/Tideways.php
 ```
 
 See: https://phpstan.org/user-guide/stub-files
+
+However, if you want to be able to run PHPStan even without the tideways extension installed, add the stub file to `scanFiles` instead.
+
+```neon
+parameters:
+    scanFiles:
+        - vendor/tideways/ext-tideways-stubs/stubs/Tideways.php
+```


### PR DESCRIPTION
This PR fixes a typo in the documented composer command.

Apart from that, I'd like to propose an improvement to the documentation on PHPStan. I've had the problem that I'd like to run PHPStan in an environment where I don't have the Tideways extension installed. Loading the stub file as a stub does not help in that regard because stubs in PHPStan can only augment existing symbols. However, if I tell PHPStan to scan the stub instead, it uses them as its source of truth.